### PR TITLE
feat(testing): add playerIdParam to URL when required for handleOpenAltPlayer

### DIFF
--- a/ui/components/Public.jsx
+++ b/ui/components/Public.jsx
@@ -36,10 +36,28 @@ export default class Public extends React.Component {
 
   handleOpenAltPlayer = event => {
     event.preventDefault();
-    const randId = Math.random()
+
+    // check to see if a playerId is required
+    const { playerIdParam, playerIdParamExclusive } = Meteor.settings.public;
+    const playerIdParamRequired = playerIdParam && playerIdParamExclusive;
+
+    const randPlayerIdKey = Math.random()
       .toString(36)
       .substring(2, 15);
-    window.open(`/?playerIdKey=${randId}`, "_blank");
+
+    // if playerId is required, add that to URL
+    // otherwise, produce URL with just playerIdKey
+    if (playerIdParamRequired) {
+      const randId = Math.random()
+        .toString(36)
+        .substring(2, 15);
+      window.open(
+        `/?playerIdKey=${randPlayerIdKey}&${playerIdParam}=${randId}`,
+        "_blank"
+      );
+    } else {
+      window.open(`/?playerIdKey=${randPlayerIdKey}`, "_blank");
+    }
   };
 
   render() {


### PR DESCRIPTION
Add playerIdParam to URL when required

## Description
Modified `Public.jsx`
This copies the logic from PublicContainer to determine "if playerId is required".  Then, if it is required, adds a random playerIdParam to the URL when handleOpenAltPlayer is called, i.e., when the experimenter clicks "New Player" in testing.


## Motivation and Context
The requirement to manually enter a Player ID in testing slows down the development process.

## How Has This Been Tested?
Tested with Ubuntu 18.04 (server) and Chrome browser in Windows (client)

No impact on other code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
