### PR TITLE
Fixes/bulk operations db 90

### DIFF
--- a/api/games/create.js
+++ b/api/games/create.js
@@ -54,7 +54,6 @@ export const createGameFromLobby = gameLobby => {
   // Ask (experimenter designer) init function to configure this game
   // given the factors and players given.
   const params = { data: {}, rounds: [], players };
-  // console.log('\n\nini params 1 ', params)
   var gameCollector = {
     players,
     treatment: factors,
@@ -284,7 +283,6 @@ export const createGameFromLobby = gameLobby => {
       .map(ids => ids._id);
     StagesOp = Stages.rawCollection().initializeUnorderedBulkOp();
 
-    // bulk.find({ appid }).upsert().updateOne({ $set: game });
     stageIds.forEach(stageId =>
       StagesOp.find({ stageId })
         .upsert()

--- a/api/games/create.js
+++ b/api/games/create.js
@@ -54,6 +54,7 @@ export const createGameFromLobby = gameLobby => {
   // Ask (experimenter designer) init function to configure this game
   // given the factors and players given.
   const params = { data: {}, rounds: [], players };
+  // console.log('\n\nini params 1 ', params)
   var gameCollector = {
     players,
     treatment: factors,
@@ -184,55 +185,141 @@ export const createGameFromLobby = gameLobby => {
   let stageIndex = 0;
   let totalDuration = 0;
   let firstRoundId;
-  params.roundIds = params.rounds.map((round, index) => {
-    const roundId = Rounds.insert(_.extend({ gameId, index }, round), {
-      autoConvert: false,
-      filter: false,
-      validate: false,
-      trimStrings: false,
-      removeEmptyStrings: false
-    });
-    const stageIds = round.stages.map(stage => {
+
+  const insertOption = {
+    autoConvert: false,
+    filter: false,
+    validate: false,
+    trimStrings: false,
+    removeEmptyStrings: false
+  };
+
+  let RoundsOp = Rounds.rawCollection().initializeUnorderedBulkOp();
+  let StagesOp = Stages.rawCollection().initializeUnorderedBulkOp();
+  let roundsOpResult;
+  let stagesOpResult;
+
+  params.rounds.forEach((round, index) =>
+    RoundsOp.insert(
+      _.extend(
+        {
+          gameId,
+          index,
+          _id: Random.id(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        round
+      ),
+      insertOption
+    )
+  );
+
+  roundsOpResult = Meteor.wrapAsync(RoundsOp.execute, RoundsOp)();
+
+  const roundIds = roundsOpResult.getInsertedIds().map(ids => ids._id);
+  RoundsOp = Rounds.rawCollection().initializeUnorderedBulkOp();
+
+  params.rounds.forEach((round, index) => {
+    const roundId = roundIds[index];
+    const { players } = params;
+
+    StagesOp = Stages.rawCollection().initializeUnorderedBulkOp();
+    let PlayerStagesOp = PlayerStages.rawCollection().initializeUnorderedBulkOp();
+    let PlayerRoundsOp = PlayerRounds.rawCollection().initializeUnorderedBulkOp();
+
+    round.stages.forEach(stage => {
       if (batch.debugMode) {
         stage.durationInSeconds = 60 * 60; // Stage time in debugMode is 1h
       }
+
       totalDuration += stage.durationInSeconds;
-      const sParams = _.extend({ gameId, roundId, index: stageIndex }, stage);
-      const stageId = Stages.insert(sParams, {
-        autoConvert: false,
-        filter: false,
-        validate: false,
-        trimStrings: false,
-        removeEmptyStrings: false
-      });
+
+      const sParams = _.extend(
+        {
+          gameId,
+          roundId,
+          index: stageIndex,
+          _id: Random.id(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        },
+        stage
+      );
+
+      StagesOp.insert(sParams, insertOption);
+
       stageIndex++;
+    });
+
+    stagesOpResult = Meteor.wrapAsync(StagesOp.execute, StagesOp)();
+    const stageIds = stagesOpResult.getInsertedIds().map(ids => ids._id);
+
+    stageIds.forEach(stageId => {
       if (!params.currentStageId) {
         firstRoundId = roundId;
         params.currentStageId = stageId;
       }
-      const playerStageIds = params.players.map(({ _id: playerId }) => {
-        return PlayerStages.insert({
+
+      players.forEach(({ _id: playerId }) =>
+        PlayerStagesOp.insert({
           playerId,
           stageId,
           roundId,
           gameId,
-          batchId
-        });
-      });
-      Stages.update(stageId, { $set: { playerStageIds } });
-      return stageId;
+          batchId,
+          _id: Random.id(),
+          createdAt: new Date(),
+          updatedAt: new Date()
+        })
+      );
     });
-    const playerRoundIds = params.players.map(({ _id: playerId }) => {
-      return PlayerRounds.insert({
+
+    const playerStagesResult = Meteor.wrapAsync(
+      PlayerStagesOp.execute,
+      PlayerStagesOp
+    )();
+    const playerStageIds = playerStagesResult
+      .getInsertedIds()
+      .map(ids => ids._id);
+    StagesOp = Stages.rawCollection().initializeUnorderedBulkOp();
+
+    // bulk.find({ appid }).upsert().updateOne({ $set: game });
+    stageIds.forEach(stageId =>
+      StagesOp.find({ stageId })
+        .upsert()
+        .update({ $set: { playerStageIds } })
+    );
+
+    Meteor.wrapAsync(StagesOp.execute, StagesOp)();
+
+    players.forEach(({ _id: playerId }) =>
+      PlayerRoundsOp.insert({
         playerId,
         roundId,
         gameId,
-        batchId
-      });
-    });
-    Rounds.update(roundId, { $set: { stageIds, playerRoundIds } });
-    return roundId;
+        batchId,
+        _id: Random.id(),
+        data: {},
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })
+    );
+
+    const playerRoundIdsResult = Meteor.wrapAsync(
+      PlayerRoundsOp.execute,
+      PlayerRoundsOp
+    )();
+    const playerRoundIds = playerRoundIdsResult
+      .getInsertedIds()
+      .map(ids => ids._id);
+
+    RoundsOp.find({ roundId })
+      .upsert()
+      .update({ $set: { stageIds, playerRoundIds } });
   });
+
+  Meteor.wrapAsync(RoundsOp.execute, RoundsOp)();
 
   // An estimation of the finish time to help querying.
   // At the moment, this will 100% break with pausing the game/batch.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
changing normal insertion inside rounds creation into bulk operations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: https://github.com/empiricaly/meteor-empirica-core/issues/90
This change reduce the duration needed of rounds creation. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

test environment: 100 rounds, 100 stages each, 1 player
before changes: it takes 26 - 30s 
after changes: it takes 5 - 8s

test environment: 100 rounds, 5 stages each, 10 players
before changes: it takes 8 - 10s
after changes: it takes less than 5s

rounds, stages, player_rounds, player_stages collections also has been checked that still insert the same docs. 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
