### PR TITLE
fix: game end when last player exit #74

### DIFF
--- a/api/batches/status-schema.js
+++ b/api/batches/status-schema.js
@@ -13,7 +13,8 @@ export const statusSchema = new SimpleSchema({
       "finished", // Batch has finished and cannot be restarted
 
       // NOTE(np): cancelled might break a game if it's running at the moment, gotta be careful
-      "cancelled" // Batch was cancelled and cannot be restarted
+      "cancelled", // Batch was cancelled and cannot be restarted
+      "custom" // used for game.end("custom reason")
     ],
     defaultValue: "init",
     index: 1

--- a/api/game-lobbies/game-lobbies.js
+++ b/api/game-lobbies/game-lobbies.js
@@ -52,6 +52,13 @@ GameLobbies.schema = new SimpleSchema({
     index: 1
   },
 
+  endReason: {
+    label: "Ended Reason",
+    type: String,
+    optional: true,
+    regEx: /[a-zA-Z0-9_]+/
+  },
+
   // Queued players are players that have been associated with the lobby
   // but are not confirmed for the game yet. playerIds is used for confirmed
   // players

--- a/api/games/games.js
+++ b/api/games/games.js
@@ -39,6 +39,13 @@ Games.schema = new SimpleSchema({
     optional: true,
     regEx: SimpleSchema.RegEx.Id,
     index: 1
+  },
+
+  endReason: {
+    label: "Ended Reason",
+    type: String,
+    optional: true,
+    regEx: /[a-zA-Z0-9_]+/
   }
 });
 

--- a/api/player-stages/augment.js
+++ b/api/player-stages/augment.js
@@ -100,7 +100,8 @@ export const augmentPlayer = (player, stage = {}, round = {}, game = {}) => {
   player.exit = reason =>
     earlyExitPlayer.call({
       playerId,
-      exitReason: reason
+      exitReason: reason,
+      gameId: game._id
     });
   player.get = key => player.data[key];
   player.set = set(player.data, playerSet(playerId));

--- a/api/players/methods.js
+++ b/api/players/methods.js
@@ -389,6 +389,30 @@ export const earlyExitPlayer = new ValidatedMethod({
       return;
     }
 
+    const game = Games.findOne(gameId);
+
+    if (!game) {
+      throw new Error("game not found");
+    }
+
+    if (game && game.finishedAt) {
+      if (Meteor.isDevelopment) {
+        console.log("\n\ngame already ended!");
+      }
+
+      return;
+    }
+
+    const currentPlayer = Players.findOne(playerId);
+
+    if (currentPlayer && currentPlayer.exitAt) {
+      if (Meteor.isDevelopment) {
+        console.log("\nplayer already exited!");
+      }
+
+      return;
+    }
+
     Players.update(playerId, {
       $set: {
         exitAt: new Date(),
@@ -405,7 +429,7 @@ export const earlyExitPlayer = new ValidatedMethod({
         $set: {
           finishedAt: new Date(),
           status: "custom",
-          endReason: "finished early"
+          endReason: "finished_early"
         }
       });
 
@@ -414,7 +438,7 @@ export const earlyExitPlayer = new ValidatedMethod({
         {
           $set: {
             status: "custom",
-            endReason: "finished early"
+            endReason: "finished_early"
           }
         }
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

adding condition to end the game immediately when last player exit

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/empiricaly/meteor-empirica-core/issues/74

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

tested with single and multiplayer, the game ended immediately after the last player has exit. The status on the batches page changed from "running" into "finished"

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
