### PR TITLE
Include elapsed time om 

### DIFF
--- a/ui/components/StageTimeWrapper.jsx
+++ b/ui/components/StageTimeWrapper.jsx
@@ -14,6 +14,7 @@ export default withTracker(({ stage, player, ...rest }) => {
   const timedOut = stage && player && !player.stage.submitted && ended;
   const roundOver = (stage && player && player.stage.submitted) || timedOut;
   const remainingSeconds = stage && endTimeAt.diff(now, "seconds");
+  const elapsedSeconds = stage && now.diff(startTimeAt, "seconds")
   return {
     timedOut,
     roundOver,
@@ -24,6 +25,7 @@ export default withTracker(({ stage, player, ...rest }) => {
     endTimeAt,
     now,
     remainingSeconds,
+    elapsedSeconds,
     ...rest
   };
 });

--- a/ui/components/StageTimeWrapper.jsx
+++ b/ui/components/StageTimeWrapper.jsx
@@ -14,7 +14,7 @@ export default withTracker(({ stage, player, ...rest }) => {
   const timedOut = stage && player && !player.stage.submitted && ended;
   const roundOver = (stage && player && player.stage.submitted) || timedOut;
   const remainingSeconds = stage && endTimeAt.diff(now, "seconds");
-  const elapsedSeconds = stage && now.diff(startTimeAt, "seconds")
+  const elapsedSeconds = stage && now.diff(startTimeAt, "seconds");
   return {
     timedOut,
     roundOver,


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
created an `elapsedTime` property for the `StageTimeWrapper`


## Motivation and Context
Want to enable the "next" button only after a certain time has elapsed, without having to know how long the stage will be. Invert the logic in this line: https://github.com/amaatouq/guess-the-correlation/blob/master/client/game/TaskResponse.jsx#L24


## How Has This Been Tested?
Leaves existing UI intact

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. **<-- is there one?**
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
