### PR TITLE
fix: remove gameInit throw #125

### DIFF
--- a/api/batches/status-schema.js
+++ b/api/batches/status-schema.js
@@ -14,6 +14,7 @@ export const statusSchema = new SimpleSchema({
 
       // NOTE(np): cancelled might break a game if it's running at the moment, gotta be careful
       "cancelled", // Batch was cancelled and cannot be restarted
+      "failed",
       "custom" // used for game.end("custom reason")
     ],
     defaultValue: "init",

--- a/api/game-lobbies/methods.js
+++ b/api/game-lobbies/methods.js
@@ -93,7 +93,7 @@ export const earlyExitGameLobby = new ValidatedMethod({
       {
         $set: {
           exitAt: new Date(),
-          exitStatus: "custom",
+          exitStatus: "failed",
           exitReason
         }
       }
@@ -101,7 +101,7 @@ export const earlyExitGameLobby = new ValidatedMethod({
 
     GameLobbies.update(gameLobbyId, {
       $set: {
-        status: "custom",
+        status: "failed",
         endReason: exitReason
       }
     });
@@ -110,7 +110,7 @@ export const earlyExitGameLobby = new ValidatedMethod({
       { gameLobbyIds: gameLobbyId },
       {
         $set: {
-          status: "cancelled",
+          status: "failed",
           finishedAt: new Date()
         }
       }

--- a/api/games/create.js
+++ b/api/games/create.js
@@ -84,46 +84,50 @@ export const createGameFromLobby = gameLobby => {
         },
 
         addStage({ name, displayName, durationInSeconds, data = {} }) {
-          if (!name || !displayName || !durationInSeconds) {
-            log.error(addStageErrMsg);
-            log.error(
-              `Got: ${JSON.stringify(
-                { name, displayName, durationInSeconds },
-                null,
-                "  "
-              )}
-`
-            );
-            return;
-            // throw "gameInit error";
-          }
-
-          const durationInSecondsAsInt = parseInt(durationInSeconds);
-          if (
-            Number.isNaN(durationInSecondsAsInt) ||
-            durationInSecondsAsInt < 1
-          ) {
-            console.error(
-              `Error in addStage call: durationInSeconds must be an number > 0 (name: ${name})`
-            );
-            return;
-          }
-
-          const stage = {
-            name,
-            displayName,
-            durationInSeconds: durationInSecondsAsInt
-          };
-          round.stages.push({ ...stage, data });
-          return {
-            ...stage,
-            get(k) {
-              return data[k];
-            },
-            set(k, v) {
-              data[k] = v;
+          try {
+            if (!name || !displayName || !durationInSeconds) {
+              log.error(addStageErrMsg);
+              log.error(
+                `Got: ${JSON.stringify(
+                  { name, displayName, durationInSeconds },
+                  null,
+                  "  "
+                )}`
+              );
+              throw "gameInit error";
             }
-          };
+
+            const durationInSecondsAsInt = parseInt(durationInSeconds);
+            if (
+              Number.isNaN(durationInSecondsAsInt) ||
+              durationInSecondsAsInt < 1
+            ) {
+              console.error(
+                `Error in addStage call: durationInSeconds must be an number > 0 (name: ${name})`
+              );
+            }
+
+            const stage = {
+              name,
+              displayName,
+              durationInSeconds: durationInSecondsAsInt
+            };
+            round.stages.push({ ...stage, data });
+            return {
+              ...stage,
+              get(k) {
+                return data[k];
+              },
+              set(k, v) {
+                data[k] = v;
+              }
+            };
+          } catch (error) {
+            earlyExitGameLobby.call({
+              exitReason: "initError",
+              gameLobbyId: gameLobby._id
+            });
+          }
         }
       };
     }
@@ -153,8 +157,7 @@ export const createGameFromLobby = gameLobby => {
       // This should never happen as we already verified it above.
       if (!name || !displayName || !durationInSeconds) {
         log.error(addStageErrMsg);
-        return;
-        // throw "invalid stage";
+        throw "invalid stage";
       }
     });
   });

--- a/api/games/create.js
+++ b/api/games/create.js
@@ -94,7 +94,8 @@ export const createGameFromLobby = gameLobby => {
               )}
 `
             );
-            throw "gameInit error";
+            return;
+            // throw "gameInit error";
           }
 
           const durationInSecondsAsInt = parseInt(durationInSeconds);
@@ -105,6 +106,7 @@ export const createGameFromLobby = gameLobby => {
             console.error(
               `Error in addStage call: durationInSeconds must be an number > 0 (name: ${name})`
             );
+            return;
           }
 
           const stage = {
@@ -151,7 +153,8 @@ export const createGameFromLobby = gameLobby => {
       // This should never happen as we already verified it above.
       if (!name || !displayName || !durationInSeconds) {
         log.error(addStageErrMsg);
-        throw "invalid stage";
+        return;
+        // throw "invalid stage";
       }
     });
   });

--- a/api/players/players.js
+++ b/api/players/players.js
@@ -18,6 +18,7 @@ export const exitStatuses = [
   "playerEndedLobbyWait",
   "playerLobbyTimedOut",
   "finished",
+  "failed",
   "custom"
 ];
 

--- a/ui/components/admin/AdminBatch.jsx
+++ b/ui/components/admin/AdminBatch.jsx
@@ -105,7 +105,11 @@ export default class AdminBatch extends React.Component {
       );
     }
 
-    if (batch.status === "finished" || batch.status === "cancelled") {
+    if (
+      batch.status === "finished" ||
+      batch.status === "cancelled" ||
+      batch.status === "failed"
+    ) {
       actions.push(
         <Button
           text={archived ? "Unarchive" : "Archive"}
@@ -170,6 +174,7 @@ export default class AdminBatch extends React.Component {
         statusMinimal = true;
         break;
       case "stopped":
+      case "failed":
       case "cancelled":
         statusIntent = Intent.DANGER;
         statusMinimal = true;

--- a/ui/components/admin/AdminBatchGame.jsx
+++ b/ui/components/admin/AdminBatchGame.jsx
@@ -50,6 +50,10 @@ export default class AdminBatchGame extends React.Component {
       statusIntent = Intent.DANGER;
       statusMinimal = true;
       statusMsg = "batch cancelled";
+    } else if (batch.status === "failed") {
+      statusIntent = Intent.DANGER;
+      statusMinimal = true;
+      statusMsg = "failed";
     } else if (batch.status === "stopped") {
       statusIntent = Intent.DANGER;
       statusMinimal = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
will not throw error when there is one of stage is invalid, instead we will end game and move players into exit with status failed. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/empiricaly/meteor-empirica-core/issues/125

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested with first stage with invalid duration (null), game didn't throw. status on each player and game was failed. 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
