### PR TITLE
fix: player.exit function before the game started #144

### DIFF
--- a/api/player-stages/augment.js
+++ b/api/player-stages/augment.js
@@ -3,7 +3,11 @@ import { updateGameData, earlyExitGame } from "../games/methods.js";
 import { updateGameLobbyData } from "../game-lobbies/methods";
 import { updatePlayerRoundData } from "../player-rounds/methods";
 import { PlayerRounds } from "../player-rounds/player-rounds";
-import { updatePlayerData, earlyExitPlayer } from "../players/methods.js";
+import {
+  updatePlayerData,
+  earlyExitPlayer,
+  earlyExitPlayerLobby
+} from "../players/methods.js";
 import { playerLog } from "../player-logs/methods.js";
 import { updateRoundData } from "../rounds/methods.js";
 import { updateStageData } from "../stages/methods.js";
@@ -92,6 +96,35 @@ export const augmentGameLobby = gameLobby => {
   gameLobby.get = key => gameLobby.data[key];
   gameLobby.set = set(gameLobby.data, gameLobbySet(gameLobby._id));
   gameLobby.append = append(gameLobby.data, gameLobbySet(gameLobby._id, true));
+};
+
+export const augmentPlayerLobby = (
+  player,
+  round = {},
+  stage = {},
+  gameLobby = {}
+) => {
+  const { _id: playerId } = player;
+
+  player.exit = reason =>
+    earlyExitPlayerLobby.call({
+      playerId,
+      exitReason: reason,
+      gameLobbyId: gameLobby._id
+    });
+  player.get = key => player.data[key];
+  player.set = set(player.data, playerSet(playerId));
+  player.append = append(player.data, playerSet(playerId, true));
+  player.log = (name, data) => {
+    playerLog.call({
+      playerId,
+      name,
+      jsonData: JSON.stringify(data),
+      stageId: stage._id,
+      roundId: round._id,
+      gameLobbyId: gameLobby._id
+    });
+  };
 };
 
 export const augmentPlayer = (player, stage = {}, round = {}, game = {}) => {

--- a/api/players/methods.js
+++ b/api/players/methods.js
@@ -446,6 +446,56 @@ export const earlyExitPlayer = new ValidatedMethod({
   }
 });
 
+export const earlyExitPlayerLobby = new ValidatedMethod({
+  name: "Players.methods.admin.earlyExitPlayerLobby",
+
+  validate: new SimpleSchema({
+    exitReason: {
+      label: "Reason for Exit",
+      type: String,
+      regEx: /[a-zA-Z0-9_]+/
+    },
+    playerId: {
+      type: String,
+      regEx: SimpleSchema.RegEx.Id
+    },
+    gameLobbyId: {
+      type: String,
+      regEx: SimpleSchema.RegEx.Id
+    }
+  }).validator(),
+
+  run({ exitReason, playerId, gameLobbyId }) {
+    if (!Meteor.isServer) {
+      return;
+    }
+
+    const gameLobby = GameLobbies.findOne(gameLobbyId);
+
+    if (!gameLobby) {
+      throw new Error("gameLobby not found");
+    }
+
+    const currentPlayer = Players.findOne(playerId);
+
+    if (currentPlayer && currentPlayer.exitAt) {
+      if (Meteor.isDevelopment) {
+        console.log("\nplayer already exited!");
+      }
+
+      return;
+    }
+
+    Players.update(playerId, {
+      $set: {
+        exitAt: new Date(),
+        exitStatus: "custom",
+        exitReason
+      }
+    });
+  }
+});
+
 export const retireGameFullPlayers = new ValidatedMethod({
   name: "Players.methods.admin.retireGameFull",
 

--- a/ui/containers/GameContainer.jsx
+++ b/ui/containers/GameContainer.jsx
@@ -7,6 +7,7 @@ import { PlayerRounds } from "../../api/player-rounds/player-rounds";
 import {
   augmentGameStageRound,
   augmentPlayer,
+  augmentPlayerLobby,
   augmentPlayerStageRound,
   augmentGameLobby
 } from "../../api/player-stages/augment";
@@ -146,10 +147,10 @@ export default withTracker(({ player, gameLobby, game, ...rest }) => {
       _id: { $in: gameLobby.playerIds }
     }).fetch();
 
-    gameLobby.players.forEach(p => augmentPlayer(p));
+    gameLobby.players.forEach(p => augmentPlayerLobby(p, {}, {}, gameLobby));
 
     augmentGameLobby(gameLobby);
-    augmentPlayer(player);
+    augmentPlayerLobby(player, {}, {}, gameLobby);
 
     return {
       ...rest,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Able to call player.exit('reason') even before the game started

## Description
<!--- Describe your changes in detail -->
Added the specific augmentFunction for players on lobby

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#144 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- called player.exit('reason') on instruction step, and player went to exit step
- called player.exit('reason') on game page, and player went to exit step

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
