### PR TITLE
fix: fix stage should not continue when all players exit or game already ended

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,8 +8,8 @@ import { callOnChange } from "./api/server/onchange.js";
 import { callOnSubmit } from "./api/server/onsubmit.js";
 import { earlyExitGame } from "./api/games/methods.js";
 import shared from "./shared";
-import log from "./lib/log";
 import { getFunctionParameters } from "./lib/utils";
+import { Games } from "./api/games/games.js";
 
 const safeCallback = function(name, func, arguments) {
   try {
@@ -25,6 +25,13 @@ const safeCallback = function(name, func, arguments) {
 
       default:
         break;
+    }
+
+    const game = Games.findOne(arguments[0]._id);
+
+    if (game.finishedAt) {
+      console.log("safeCallback: game already ended.");
+      return;
     }
 
     return func.apply(this, arguments);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix game if it ended.

## Description
<!--- Describe your changes in detail -->
Added a condition, if game already ended we will not call the next callback.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#158 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Calling `game.end()` and `player.exit()` on Empirica Callback, with single and multiplayer -> won't called next callback. 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
