### PR TITLE
feat: add option for pii inside lastLogin player #170

### DIFF
--- a/startup/server/connections.js
+++ b/startup/server/connections.js
@@ -21,13 +21,16 @@ export const playerIdForConn = conn => {
 export const savePlayerId = (conn, playerId) => {
   connections[conn.id] = playerId;
 
+  const pii = Meteor.settings.collectPII
+    ? { ip: conn.clientAddress, userAgent: conn.httpHeaders["user-agent"] }
+    : {};
+
   Players.update(playerId, {
     $set: {
       online: true,
       lastLogin: {
         at: new Date(),
-        ip: conn.clientAddress,
-        userAgent: conn.httpHeaders["user-agent"]
+        ...pii
       }
     }
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
make option for collecting PII inside lastLogin

## Description
<!--- Describe your changes in detail -->
create a setting to make pii inside lastLogin become optional

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#170 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] played a game with single player, checked the DB, the PII didn't exist on the lastLogin

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
