### PR TITLE
Fixes/lobby timeout for bot players #152

### DIFF
--- a/api/game-lobbies/hooks.js
+++ b/api/game-lobbies/hooks.js
@@ -63,7 +63,7 @@ GameLobbies.after.update(
 
     // If the readyPlayersCount went to 0 (disconnections for example), reset the
     // lobby timeout.
-    if (readyPlayersCount === 0 && gameLobby.timeoutStartedAt) {
+    if (humanPlayers.length === 0 && gameLobby.timeoutStartedAt) {
       const lobbyConfig = LobbyConfigs.findOne(gameLobby.lobbyConfigId);
       if (lobbyConfig.timeoutType === "lobby") {
         GameLobbies.update(gameLobby._id, {

--- a/api/game-lobbies/hooks.js
+++ b/api/game-lobbies/hooks.js
@@ -25,20 +25,31 @@ GameLobbies.after.update(function(
 // Start the game if lobby full
 GameLobbies.after.update(
   function(userId, doc, fieldNames, modifier, options) {
-    if (!( fieldNames.includes("playerIds") ||
-           (fieldNames.includes("status") && doc.status == "running" )
-         )){
+    if (
+      !(
+        fieldNames.includes("playerIds") ||
+        (fieldNames.includes("status") && doc.status == "running")
+      )
+    ) {
       return;
     }
 
     const gameLobby = this.transform();
+    const humanPlayers = [];
+
+    if (gameLobby.playerIds && gameLobby.playerIds.length > 0) {
+      const players = Players.find({
+        _id: { $in: gameLobby.playerIds }
+      }).fetch();
+      humanPlayers.push(...players.filter(p => !p.bot));
+    }
 
     const readyPlayersCount = gameLobby.playerIds.length;
 
     // If the lobby timeout it hasn't started yet and the lobby isn't full yet
     // (single player), try to start the timeout timer.
     if (
-      readyPlayersCount > 0 &&
+      humanPlayers.length > 0 &&
       gameLobby.availableCount != 1 &&
       !gameLobby.timeoutStartedAt
     ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
We want to make sure that the lobby should be started if there is any human player on the lobby. 
## Description
<!--- Describe your changes in detail -->
Deducted the readyPlayersCount with the bots on the game. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#152 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] played game with all human players, lobby timeout started when there was a single human player on the lobby
- [x] played game with combination of human and bot players, lobby timeout started when there was a single human version on the lobby.
- [x] reset the lobby after all human players exited the lobby. 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
