### PR TITLE
feat: add gameLobby in place of game for exit steps if player exited

### DIFF
--- a/api/player-inputs/methods.js
+++ b/api/player-inputs/methods.js
@@ -1,8 +1,7 @@
 import { ValidatedMethod } from "meteor/mdg:validated-method";
 import SimpleSchema from "simpl-schema";
-
-import { PlayerInputs } from "./player-inputs.js";
 import { Players } from "../players/players.js";
+import { PlayerInputs } from "./player-inputs.js";
 
 // addPlayerInput is non-destructive, it just keeps adding onto a player's
 // input data.
@@ -16,22 +15,31 @@ export const addPlayerInput = new ValidatedMethod({
     },
     gameId: {
       type: String,
-      regEx: SimpleSchema.RegEx.Id
+      regEx: SimpleSchema.RegEx.Id,
+      optional: true
+    },
+    gameLobbyId: {
+      type: String,
+      regEx: SimpleSchema.RegEx.Id,
+      optional: true
     },
     data: {
       type: String
     }
   }).validator(),
 
-  run({ playerId, gameId, data: rawData }) {
+  run({ playerId, gameId, gameLobbyId, data: rawData }) {
     const player = Players.findOne(playerId);
     if (!player) {
       throw new Error("player not found");
     }
+    if (!gameId && !gameLobbyId) {
+      throw new Error("gameId or gameLobbyId required");
+    }
 
     const data = JSON.parse(rawData);
     PlayerInputs.insert(
-      { playerId, gameId, data },
+      { playerId, gameId, gameLobbyId, data },
       {
         autoConvert: false,
         filter: false,

--- a/api/player-inputs/player-inputs.js
+++ b/api/player-inputs/player-inputs.js
@@ -4,8 +4,7 @@
 // movements...)
 
 import SimpleSchema from "simpl-schema";
-
-import { TimestampSchema, UserDataSchema, BelongsTo } from "../default-schemas";
+import { BelongsTo, TimestampSchema, UserDataSchema } from "../default-schemas";
 
 export const PlayerInputs = new Mongo.Collection("player_inputs");
 
@@ -13,6 +12,7 @@ PlayerInputs.schema = new SimpleSchema({});
 
 PlayerInputs.schema.extend(TimestampSchema);
 PlayerInputs.schema.extend(UserDataSchema);
-PlayerInputs.schema.extend(BelongsTo("Games"));
+PlayerInputs.schema.extend(BelongsTo("Games", false));
+PlayerInputs.schema.extend(BelongsTo("GameLobbies", false));
 PlayerInputs.schema.extend(BelongsTo("Players"));
 PlayerInputs.attachSchema(PlayerInputs.schema);

--- a/ui/components/Game.jsx
+++ b/ui/components/Game.jsx
@@ -44,7 +44,7 @@ export default class Game extends React.Component {
       return (
         <ExitSteps
           steps={exitSteps(game, player)}
-          game={game}
+          game={game || gameLobby}
           player={player}
           {...rest}
           onSubmit={(stepName, data) => {

--- a/ui/components/Game.jsx
+++ b/ui/components/Game.jsx
@@ -43,7 +43,7 @@ export default class Game extends React.Component {
     if (player.exitAt) {
       return (
         <ExitSteps
-          steps={exitSteps(game, player)}
+          steps={exitSteps(game || gameLobby, player)}
           game={game || gameLobby}
           player={player}
           {...rest}
@@ -58,7 +58,8 @@ export default class Game extends React.Component {
                 addPlayerInput.call({
                   playerId,
                   data: encoded,
-                  gameId: game._id
+                  gameId: game && game._id,
+                  gameLobbyId: game ? null : gameLobby && gameLobby._id
                 });
               } catch (e) {
                 console.error("could not encode data returned by onSubmit", e);


### PR DESCRIPTION
before game

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

We replace game with gamLobby in exit steps if Game is not available (aka user exited from lobby). This allows access to treatment from the same key (`game`) in exit steps.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#207 Expose treatment in ExitSteps if player exited in lobby

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not very well...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

New feature (non-breaking change which adds functionality)
