### PR TITLE
feat: add admin debug params to consent, intro steps and lobby

### DIFF
--- a/ui/components/Game.jsx
+++ b/ui/components/Game.jsx
@@ -73,6 +73,7 @@ export default class Game extends React.Component {
     if (!game) {
       if (player.readyAt) {
         const gameLobbyProps = {
+          ...rest,
           gameLobby,
           game: gameLobby,
           treatment,

--- a/ui/components/InstructionSteps.jsx
+++ b/ui/components/InstructionSteps.jsx
@@ -34,7 +34,7 @@ export default class InstructionSteps extends React.Component {
   };
 
   render() {
-    const { treatment, player } = this.props;
+    const { treatment, ...rest } = this.props;
     const { steps, current, noInstruction } = this.state;
 
     if (noInstruction) {
@@ -54,7 +54,7 @@ export default class InstructionSteps extends React.Component {
           onNext={this.onNext}
           treatment={conds}
           game={{ treatment: conds }}
-          player={player}
+          {...rest}
         />
       </div>
     );

--- a/ui/components/NewPlayer.jsx
+++ b/ui/components/NewPlayer.jsx
@@ -1,11 +1,10 @@
 import React from "react";
-
-import { AlertToaster } from "./Toasters.jsx";
 import { createPlayer } from "../../api/players/methods";
 import { setPlayerId } from "../containers/IdentifiedContainer.jsx";
-import NewPlayerForm from "./NewPlayerForm.jsx";
-
 import Loading from "./Loading.jsx";
+import NewPlayerForm from "./NewPlayerForm.jsx";
+import { AlertToaster } from "./Toasters.jsx";
+
 const { playerIdParam } = Meteor.settings.public;
 
 export const ConsentButtonContext = React.createContext(null);
@@ -103,7 +102,7 @@ export default class NewPlayer extends React.Component {
     if (!consented && Consent) {
       return (
         <ConsentButtonContext.Provider value={this.handleConsent}>
-          <Consent onConsent={this.handleConsent} />
+          <Consent {...this.props} onConsent={this.handleConsent} />
         </ConsentButtonContext.Provider>
       );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Passing all parent props on lobby, Consent and Intro Steps, which include props for admin debug (showOpenAltPlayer, showReset...) 

## Motivation and Context

These props were not available until now in these part of the app and we couldn't display these buttons in these parts of an app where the header was customized.
