### PR TITLE
fix: send queued players to exit when batch is cancelled #233

### DIFF
--- a/api/batches/hooks.js
+++ b/api/batches/hooks.js
@@ -61,7 +61,7 @@ Batches.after.insert(function(userId, batch) {
       if (botsCount === l.availableCount) {
         //throw "Creating a game with only bots...";
         //Would be good to display a message "Are you sure you want to create a game with only bots?"
-        console.log("Warning: Creating a game with only bots!")
+        console.log("Warning: Creating a game with only bots!");
       }
       const botNames = config.bots && _.keys(config.bots);
       if (!config.bots || botNames.length === 0) {
@@ -115,7 +115,8 @@ Batches.after.update(
       const gameLobbies = GameLobbies.find({ batchId }).fetch();
       const gplayerIds = _.flatten(_.pluck(games, "playerIds"));
       const glplayerIds = _.flatten(_.pluck(gameLobbies, "playerIds"));
-      const playerIds = _.union(gplayerIds, glplayerIds);
+      const glqplayerIds = _.flatten(_.pluck(gameLobbies, "queuedPlayerIds"));
+      const playerIds = _.union(gplayerIds, glplayerIds, glqplayerIds);
       Players.update(
         { _id: { $in: playerIds } },
         { $set: { exitStatus: "gameCancelled", exitAt: new Date() } },

--- a/api/batches/hooks.js
+++ b/api/batches/hooks.js
@@ -105,7 +105,7 @@ Batches.after.update(
       return;
     }
 
-    const games = Games.find({ batchId, status: "running" }).fetch();
+    const games = Games.find({ batchId }).fetch();
     const gplayerIds = _.flatten(_.pluck(games, "playerIds"));
 
     Players.update(
@@ -118,6 +118,11 @@ Batches.after.update(
       batchId,
       gameId: { $exists: false }
     }).fetch();
+
+    if (gameLobbies.length === 0) {
+      return;
+    }
+
     const glplayerIds = _.flatten(_.pluck(gameLobbies, "queuedPlayerIds"));
     const players = Players.find({
       _id: { $in: glplayerIds },
@@ -126,7 +131,7 @@ Batches.after.update(
 
     const playerIds = _.pluck(players, "_id");
 
-    sendPlayersToNextBatches(playerIds);
+    sendPlayersToNextBatches(playerIds, batchId, gameLobbies[0]);
   },
   { fetchPrevious: false }
 );

--- a/api/games/create.js
+++ b/api/games/create.js
@@ -381,7 +381,7 @@ export const createGameFromLobby = gameLobby => {
     gameLobby.playerIds
   );
 
-  sendPlayersToNextBatches(failedPlayerIds);
+  sendPlayersToNextBatches(failedPlayerIds, batchId, gameLobby);
 
   //
   // Call the callbacks
@@ -431,12 +431,13 @@ export const createGameFromLobby = gameLobby => {
   });
 };
 
-export function sendPlayersToNextBatches(playerIds) {
+export function sendPlayersToNextBatches(playerIds, batchId, gameLobby) {
   // Find other lobbies that are not full yet with the same treatment
   const runningBatches = Batches.find(
     { _id: { $ne: batchId }, status: "running" },
     { sort: { runningAt: 1 } }
   );
+  const { treatmentId } = gameLobby;
   const lobbiesGroups = runningBatches.map(() => []);
   const runningBatcheIds = runningBatches.map(b => b._id);
   lobbiesGroups.push([]);
@@ -492,9 +493,7 @@ export function sendPlayersToNextBatches(playerIds) {
         if (gameLobby.playerIds.includes(playerId)) {
           $addToSet.playerIds = playerId;
         }
-        GameLobbies.update(lobby._id, {
-          $addToSet
-        });
+        GameLobbies.update(lobby._id, { $addToSet });
 
         Players.update(playerId, {
           $set: {

--- a/api/games/create.js
+++ b/api/games/create.js
@@ -381,82 +381,7 @@ export const createGameFromLobby = gameLobby => {
     gameLobby.playerIds
   );
 
-  // Find other lobbies that are not full yet with the same treatment
-  const runningBatches = Batches.find(
-    {
-      _id: { $ne: batchId },
-      status: "running"
-    },
-    { sort: { runningAt: 1 } }
-  );
-  const lobbiesGroups = runningBatches.map(() => []);
-  const runningBatcheIds = runningBatches.map(b => b._id);
-  lobbiesGroups.push([]);
-  const possibleLobbies = GameLobbies.find({
-    _id: { $ne: gameLobby._id },
-    status: "running",
-    timedOutAt: { $exists: false },
-    gameId: { $exists: false },
-    treatmentId
-  }).fetch();
-  possibleLobbies.forEach(lobby => {
-    if (lobby.batchId === batchId) {
-      lobbiesGroups[0].push(lobby);
-    } else {
-      lobbiesGroups[runningBatcheIds.indexOf(lobby.batchId) + 1].push(lobby);
-    }
-  });
-
-  // If no lobbies left, lead players to exit
-  if (possibleLobbies.length === 0) {
-    Players.update(
-      { _id: { $in: failedPlayerIds } },
-      {
-        $set: {
-          exitAt: new Date(),
-          exitStatus: "gameFull"
-        }
-      },
-      { multi: true }
-    );
-  } else {
-    for (let i = 0; i < lobbiesGroups.length; i++) {
-      const lobbies = lobbiesGroups[i];
-
-      if (lobbies.length === 0) {
-        continue;
-      }
-
-      // If there are lobbies remaining, distribute them across the lobbies
-      // proportinally to the initial playerCount
-      const weigthedLobbyPool = weightedRandom(
-        lobbies.map(lobby => {
-          return {
-            value: lobby,
-            weight: lobby.availableCount
-          };
-        })
-      );
-
-      for (let i = 0; i < failedPlayerIds.length; i++) {
-        const playerId = failedPlayerIds[i];
-        const lobby = weigthedLobbyPool();
-
-        // Adding the player to specified lobby queue
-        const $addToSet = { queuedPlayerIds: playerId };
-        if (gameLobby.playerIds.includes(playerId)) {
-          $addToSet.playerIds = playerId;
-        }
-        GameLobbies.update(lobby._id, {
-          $addToSet
-        });
-
-        Players.update(playerId, { $set: { gameLobbyId: lobby._id } });
-      }
-
-      break;
-    }
-  }
+  sendPlayersToNextBatches(failedPlayerIds);
 
   //
   // Call the callbacks
@@ -505,3 +430,80 @@ export const createGameFromLobby = gameLobby => {
     }
   });
 };
+
+export function sendPlayersToNextBatches(playerIds) {
+  // Find other lobbies that are not full yet with the same treatment
+  const runningBatches = Batches.find(
+    { _id: { $ne: batchId }, status: "running" },
+    { sort: { runningAt: 1 } }
+  );
+  const lobbiesGroups = runningBatches.map(() => []);
+  const runningBatcheIds = runningBatches.map(b => b._id);
+  lobbiesGroups.push([]);
+  const possibleLobbies = GameLobbies.find({
+    _id: { $ne: gameLobby._id },
+    status: "running",
+    timedOutAt: {
+      $exists: false
+    },
+    gameId: { $exists: false },
+    treatmentId
+  }).fetch();
+  possibleLobbies.forEach(lobby => {
+    if (lobby.batchId === batchId) {
+      lobbiesGroups[0].push(lobby);
+    } else {
+      lobbiesGroups[runningBatcheIds.indexOf(lobby.batchId) + 1].push(lobby);
+    }
+  });
+
+  // If no lobbies left, lead players to exit
+  if (possibleLobbies.length === 0) {
+    Players.update(
+      { _id: { $in: playerIds } },
+      { $set: { exitAt: new Date(), exitStatus: "gameFull" } },
+      { multi: true }
+    );
+  } else {
+    for (let i = 0; i < lobbiesGroups.length; i++) {
+      const lobbies = lobbiesGroups[i];
+
+      if (lobbies.length === 0) {
+        continue;
+      }
+
+      // If there are lobbies remaining, distribute them across the lobbies
+      // proportinally to the initial playerCount
+      const weigthedLobbyPool = weightedRandom(
+        lobbies.map(lobby => {
+          return {
+            value: lobby,
+            weight: lobby.availableCount
+          };
+        })
+      );
+
+      for (let i = 0; i < playerIds.length; i++) {
+        const playerId = playerIds[i];
+        const lobby = weigthedLobbyPool();
+
+        // Adding the player to specified lobby queue
+        const $addToSet = { queuedPlayerIds: playerId };
+        if (gameLobby.playerIds.includes(playerId)) {
+          $addToSet.playerIds = playerId;
+        }
+        GameLobbies.update(lobby._id, {
+          $addToSet
+        });
+
+        Players.update(playerId, {
+          $set: {
+            gameLobbyId: lobby._id
+          }
+        });
+      }
+
+      break;
+    }
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
make queued players on gameLobbies go to exit if batch is cancelled

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#233 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Create a game and player stay on the intro pages, cancelled the batch from the admin. players go to exit page.

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
