### PR TITLE
fix: fix reset games and entire app delete entire custom collections …

### DIFF
--- a/api/admin/methods.js
+++ b/api/admin/methods.js
@@ -10,8 +10,20 @@ import { bootstrap } from "../../startup/server/bootstrap.js";
 import log from "../../lib/log.js";
 
 const userColls = ["meteor_accounts_loginServiceConfiguration", "users"];
-const keep = [].concat(userColls);
 const keepPartial = ["treatments", "factors", "factor_types", "lobby_configs"];
+const deleteColls = [
+  "game_lobbies",
+  "player_inputs",
+  "batches",
+  "rounds",
+  "counters",
+  "games",
+  "player_rounds",
+  "players",
+  "player_stages",
+  "player_logs",
+  "stages"
+].concat(keepPartial);
 
 const localTypeForImported = data => {
   return factorTypeId => {
@@ -58,8 +70,8 @@ const archivedUpdate = (archivedAt, existingArchivedAt) =>
   !!archivedAt === !!existingArchivedAt
     ? null
     : archivedAt
-      ? { $set: { archivedAt: new Date() } }
-      : { $unset: { archivedAt: true, archivedById: true } };
+    ? { $set: { archivedAt: new Date() } }
+    : { $unset: { archivedAt: true, archivedById: true } };
 
 Meteor.methods({
   adminImportConfiguration({ text }) {
@@ -231,7 +243,7 @@ if (Meteor.isDevelopment || Meteor.settings.public.debug_resetDatabase) {
           }
           colls = _.sortBy(colls, c => (c.name === "players" ? 0 : 1));
           colls.forEach(collection => {
-            if (keep.includes(collection.name)) {
+            if (!deleteColls.includes(collection.name)) {
               return;
             }
             if (partial && keepPartial.includes(collection.name)) {


### PR DESCRIPTION
#251

<!--- Provide a general summary of your changes in the Title above -->

Reset games and entire app will not delete the entire custom collections. 

## Description
<!--- Describe your changes in detail -->
Changed the list of keep collections into delete collections. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#251 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Created a custom collection into current db
- Reset games, keep partial collections and keep the custom collections
- Reset entire app, keep the custom collections 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
