### PR TITLE
fix: lock gameInit to avoid gameFull status on player #255

### DIFF
--- a/gameLobby-lock.js
+++ b/gameLobby-lock.js
@@ -1,0 +1,3 @@
+const gameLobbyLock = {};
+
+export default gameLobbyLock;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,14 @@ import {
   isElement
 } from "./componentChecker";
 
+export const sleep = ms => {
+  return new Promise(function(resolve, _) {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+};
+
 export const weightedRandom = values => {
   const samples = [];
 

--- a/ui/components/Game.jsx
+++ b/ui/components/Game.jsx
@@ -16,6 +16,8 @@ import WaitingForServer from "./WaitingForServer.jsx";
 const DelayedWaitingForServer = DelayedDisplay(WaitingForServer, 250);
 const DelayedGameLobby = DelayedDisplay(GameLobby, 250);
 
+let playerReadyClicked = false;
+
 export default class Game extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return !_.isEqual(this.props, nextProps);
@@ -71,6 +73,10 @@ export default class Game extends React.Component {
     }
 
     if (!game) {
+      if (playerReadyClicked) {
+        return <Loading />;
+      }
+
       if (player.readyAt) {
         const gameLobbyProps = {
           ...rest,
@@ -98,7 +104,10 @@ export default class Game extends React.Component {
           treatment={treatment}
           player={player}
           onDone={() => {
-            playerReady.call({ _id: player._id });
+            playerReadyClicked = true;
+            playerReady.call({ _id: player._id }, () => {
+              playerReadyClicked = false;
+            });
           }}
         />
       );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Lock gameLobby on init 
## Description
<!--- Describe your changes in detail -->
Lock gameLobby on init to avoid player get a `gameFull` status.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#255 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
