### PR TITLE
fix white space created by header by changing nav bar classes

### DIFF
--- a/ui/components/Public.jsx
+++ b/ui/components/Public.jsx
@@ -145,8 +145,8 @@ export default class Public extends React.Component {
         {Header !== undefined ? (
           <Header {...adminProps} />
         ) : (
-          <Navbar className={["header", Classes.DARK].join(" ")}>
-            <NavbarGroup align="left">
+          <div className="header navbar">
+            <div className="navbarGroup">
               <NavbarHeading>
                 <Link
                   className={[
@@ -161,8 +161,9 @@ export default class Public extends React.Component {
                   <span className={Classes.BUTTON_TEXT}>Empirica</span>
                 </Link>
               </NavbarHeading>
-            </NavbarGroup>
-            <NavbarGroup align="right">
+            </div>
+
+            <div className="navbarGroup">
               {showOpenAltPlayer ? (
                 <Button
                   text="New Player"
@@ -226,8 +227,8 @@ export default class Public extends React.Component {
                   </Dialog>
                 </>
               ) : null}
-            </NavbarGroup>
-          </Navbar>
+            </div>
+          </div>
         )}
 
         <main>{content}</main>

--- a/ui/components/Public.jsx
+++ b/ui/components/Public.jsx
@@ -10,8 +10,6 @@ import {
   Dialog,
   Icon,
   Intent,
-  Navbar,
-  NavbarGroup,
   NavbarHeading
 } from "@blueprintjs/core";
 import { IconNames } from "@blueprintjs/icons";

--- a/ui/stylesheets/admin.less
+++ b/ui/stylesheets/admin.less
@@ -2,6 +2,18 @@ body.bp3-dark {
   background-color: #30404d;
 }
 
+.navbar {
+  display: flex;
+  background-color: #30404d;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: 1rem;
+
+  * {
+    color: white;
+  }
+}
+
 .admin {
   height: 100%;
   width: 100%;


### PR DESCRIPTION

## Description
I took out the blueprint `Navbar` and `NavbarGroup` components for `div`s with their own classes. I have added a class to `admin.less`. This allows for more control over the styling of these elements. Notably, it allows for using flex boxes instead of aligns, preventing the problem where it caused white screen on smaller screen sizes.

## Motivation and Context
It fixes this issue: #252 

## How Has This Been Tested?
Connected a basic template Empirica app to my modified empirica-core code. Made sure it the styling did what it was supposed to do in Firefox and Chrome. Testing from WSL Ubuntu.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/60732953/125640424-cc5d8393-04ff-493b-b7ac-78b7f57accee.png)

![image](https://user-images.githubusercontent.com/60732953/125640461-428372f8-43b8-4d0f-9f15-fd0e43871ce4.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I tried my best to check that it was working and that it was helpful. I am happy to hear how this might need to be tweaked further. First time I am doing a change for a big repo like this one.
