### PR TITLE
feat: make submittedAt available on stage

### DIFF
--- a/api/player-stages/augment.js
+++ b/api/player-stages/augment.js
@@ -175,6 +175,7 @@ export const augmentPlayerStageRound = (
       }
     });
     stage.submitted = Boolean(playerStage.submittedAt);
+    stage.submittedAt = playerStage.submittedAt;
   }
 
   if (round) {


### PR DESCRIPTION
To be able to use `submittedAt` while the game is ongoing.